### PR TITLE
.NET 8 RC1

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -47,6 +47,7 @@ jobs:
               -f ${{ env.WORKLOAD_NAME }}-compose.yaml \
               -f base-compose.yaml \
               up \
+              --build \
               -d \
               --wait \
               --wait-timeout 30

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -20,7 +20,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.1-alpine3.18-amd64@sha256:1f
 WORKDIR /app
 COPY --from=builder /my-sample-app .
 EXPOSE 8080
-ENV ASPNETCORE_URLS=http://*:8080
+ENV ASPNETCORE_HTTP_PORTS=8080
 ENV DOTNET_EnableDiagnostics=0
 USER 1000
 ENTRYPOINT ["/app/my-sample-app"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0.401-alpine3.18@sha256:ba04d2d249d045c4324f8f238f0b82a08528a61db969ba9b0c549b8bc1dc9127 as builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-rc.1-alpine3.18-amd64@sha256:22d2de7f9568bc05083bd834b6fcfa0066dec6a62570b943ac98c9c56b7a372c as builder
 WORKDIR /app
 COPY my-sample-app.csproj .
 RUN dotnet restore my-sample-app.csproj \
@@ -14,7 +14,7 @@ RUN dotnet publish my-sample-app.csproj \
     -p:PublishTrimmed=true \
     -p:TrimMode=full
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0.11-alpine3.18@sha256:276b70790c33051bcf79ada1fc2dd91428330c9e02a7d0aaf27d070f096793cf
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.1-alpine3.18-amd64@sha256:1f58b2f92e2720df01ade6fd1c9e6cc69b79beddbebced5eb128eb3d5e83d8ef
 WORKDIR /app
 COPY --from=builder /my-sample-app .
 EXPOSE 8080

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,6 @@
 # https://mcr.microsoft.com/en-us/product/dotnet/sdk
 FROM mcr.microsoft.com/dotnet/sdk:8.0.100-rc.1-alpine3.18-amd64@sha256:22d2de7f9568bc05083bd834b6fcfa0066dec6a62570b943ac98c9c56b7a372c as builder
+RUN apk add clang build-base zlib-dev
 WORKDIR /app
 COPY my-sample-app.csproj .
 RUN dotnet restore my-sample-app.csproj \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,3 +1,4 @@
+# https://mcr.microsoft.com/en-us/product/dotnet/sdk
 FROM mcr.microsoft.com/dotnet/sdk:8.0.100-rc.1-alpine3.18-amd64@sha256:22d2de7f9568bc05083bd834b6fcfa0066dec6a62570b943ac98c9c56b7a372c as builder
 WORKDIR /app
 COPY my-sample-app.csproj .
@@ -14,6 +15,7 @@ RUN dotnet publish my-sample-app.csproj \
     -p:PublishTrimmed=true \
     -p:TrimMode=full
 
+# https://mcr.microsoft.com/en-us/product/dotnet/runtime-deps
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.1-alpine3.18-amd64@sha256:1f58b2f92e2720df01ade6fd1c9e6cc69b79beddbebced5eb128eb3d5e83d8ef
 WORKDIR /app
 COPY --from=builder /my-sample-app .

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,7 +11,6 @@ RUN dotnet publish my-sample-app.csproj \
     -o /my-sample-app \
     --no-restore \
     --self-contained true \
-    -p:PublishSingleFile=true \
     -p:PublishTrimmed=true \
     -p:TrimMode=full
 

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 var app = builder.Build();
 
 var message = builder.Configuration["MESSAGE"];

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
 </Project>

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot>true</PublishAot>
   </PropertyGroup>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+</PropertyGroup>
 </Project>

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup>
     <PublishAot>true</PublishAot>
     <OptimizationPreference>Size</OptimizationPreference>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -4,5 +4,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <PublishAot>true</PublishAot>
+    <OptimizationPreference>Size</OptimizationPreference>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <StackTraceSupport>false</StackTraceSupport>
 </PropertyGroup>
 </Project>


### PR DESCRIPTION
Before the updates, with .NET 7, the latest image size on disk was: 31.7MB.

1st updates:
- `mcr.microsoft.com/dotnet/sdk:8.0.100-rc.1-alpine3.18-amd64`
- `mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.1-alpine3.18-amd64`
- `<TargetFramework>net8.0</TargetFramework>`

Size (on disk): 102 MB

2nd updates:
- `<PublishAot>true</PublishAot>`
- `RUN apk add clang build-base zlib-dev`
- Remove: `-p:PublishSingleFile=true` incompatible with `PublishAot`

Size (on disk): 61.5 MB

3rd updates:
- `OptimizationPreference=Size`
- `InvariantGlobalization=true`
- `StackTraceSupport=false`

Size (on disk): 60.2 MB

4th updates:
- `CreateSlimBuilder`

Size (on disk): 40.5 MB

Other updates not impacting the size:
- `ASPNETCORE_HTTP_PORTS`

To conclude, .NET 7 --> .NET 8 (+ `PublishAot` + `SlimBuilder`): 31.7MB --> 40.5 MB (+ 22 %) on disk.