### PR TITLE
`noble-chiseled`

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,9 +3,11 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af120bff652658c6c985ccf63e62f12ce49127cc7 as builder
 WORKDIR /app
 COPY my-sample-app.csproj .
-RUN dotnet restore my-sample-app.csproj
+RUN dotnet restore my-sample-app.csproj \
+    -r linux-x64
 COPY . .
-RUN dotnet publish my-sample-app.csproj
+RUN dotnet publish my-sample-app.csproj \
+    -r linux-x64 \
     -c release \
     -o /my-sample-app \
     --no-restore \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 # https://mcr.microsoft.com/product/dotnet/sdk
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:8.0.301-alpine3.18-amd64@sha256:5ccd7acc1ff31f2a0377bcbc50bd0553c28d65cd4f5ec4366e68966aea60bf2f as builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af120bff652658c6c985ccf63e62f12ce49127cc7 as builder
 RUN apk add clang build-base zlib-dev
 WORKDIR /app
 COPY my-sample-app.csproj .
@@ -18,7 +18,7 @@ RUN dotnet publish my-sample-app.csproj \
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-alpine3.18-amd64@sha256:c76f58ad2aa1e0c4a61efb38222be359b434e1eae731fac8d806a3a3ef966bb5
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@sha256:1745aa8e322b6965ea3ec8524b9f9eb128f146c804e32b1fc2272ed07ada4c8e
 WORKDIR /app
 COPY --from=builder /my-sample-app .
 EXPOSE 8080

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,6 @@
 # https://mcr.microsoft.com/product/dotnet/sdk
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
 FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af120bff652658c6c985ccf63e62f12ce49127cc7 as builder
-RUN apk add clang build-base zlib-dev
 WORKDIR /app
 COPY my-sample-app.csproj .
 RUN dotnet restore my-sample-app.csproj

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 # https://mcr.microsoft.com/product/dotnet/sdk
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af120bff652658c6c985ccf63e62f12ce49127cc7 as builder
+FROM mcr.microsoft.com/dotnet/nightly/sdk:8.0-noble-aot as builder
 WORKDIR /app
 COPY my-sample-app.csproj .
 RUN dotnet restore my-sample-app.csproj \
@@ -17,7 +17,7 @@ RUN dotnet publish my-sample-app.csproj \
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@sha256:1745aa8e322b6965ea3ec8524b9f9eb128f146c804e32b1fc2272ed07ada4c8e
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-noble-chiseled-aot
 WORKDIR /app
 COPY --from=builder /my-sample-app .
 EXPOSE 8080

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,11 +4,9 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af
 RUN apk add clang build-base zlib-dev
 WORKDIR /app
 COPY my-sample-app.csproj .
-RUN dotnet restore my-sample-app.csproj \
-    -r linux-musl-x64
+RUN dotnet restore my-sample-app.csproj
 COPY . .
-RUN dotnet publish my-sample-app.csproj \
-    -r linux-musl-x64 \
+RUN dotnet publish my-sample-app.csproj
     -c release \
     -o /my-sample-app \
     --no-restore \

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot>true</PublishAot>
+    <PublishAot>false</PublishAot>
     <OptimizationPreference>Size</OptimizationPreference>
     <InvariantGlobalization>true</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>

--- a/app/my-sample-app.csproj
+++ b/app/my-sample-app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot>false</PublishAot>
+    <PublishAot>true</PublishAot>
     <OptimizationPreference>Size</OptimizationPreference>
     <InvariantGlobalization>true</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>


### PR DESCRIPTION
Moving from `alpine` to `chiseled` (i.e. `distroless`).

Resources:
- https://devblogs.microsoft.com/dotnet/whats-new-for-dotnet-in-ubuntu-2404/
- https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile.ubuntu-chiseled
- https://build.microsoft.com/en-US/sessions/fe58e8ce-6a0d-42d9-911f-9ebfe44d6dad

Todos:
- [X] Test locally Docker --> `make compose-test`
- [X] Test locally with Kind cluster --> `make k8s-test`
- [X] Test in my GKE cluster --> `humctl score deploy`
- [X] Compare differences between before and after for size, number of packages and number of CVEs
- [X] Confirm the use of `noble` (Ubuntu 24.04) versus `jammy` (Ubuntu 22.04) --> [`noble` is LTS](https://ubuntu.com/blog/canonical-releases-ubuntu-24-04-noble-numbat)
- [X] Contribute to the OnlineBoutique sample apps repo with the same approach: https://github.com/GoogleCloudPlatform/microservices-demo/pull/2568
- [X] Confirm the use of `nightly` container images (for the support of `-aot`) - [`-aot` are in Preview for now](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-variants.md#preview-aot-net-80), but I can live with this, because of all the benefits (size, etc.)
- [ ] Update my blog posts:
  - [ ] https://medium.com/p/c68ba253844a
  - [X] https://medium.com/p/caac35250e0b

## Size (+1.5 MB)

- Before: `40.9 MB`
- After: `42.4 MB` --> +`1.5 MB`, I can live with this, that's for sure! ;)

## Packages (-11 packages)

_Note: [`syft`](https://github.com/anchore/syft) was used._

Before:
```
✔ Packages                               [17 packages]
   ├── ✔ File digests                    [81 files]
   ├── ✔ File metadata                   [81 locations]
   └── ✔ Executables                     [21 executables]
NAME                    VERSION                 TYPE
alpine-baselayout       3.4.3-r1                apk
alpine-baselayout-data  3.4.3-r1                apk
alpine-keys             2.4-r1                  apk
apk-tools               2.14.0-r2               apk
busybox                 1.36.1-r5               apk
busybox-binsh           1.36.1-r5               apk
ca-certificates-bundle  20230506-r0             apk
libc-utils              0.7.2-r5                apk
libcrypto3              3.1.4-r5                apk
libgcc                  12.2.1_git20220924-r10  apk
libssl3                 3.1.4-r5                apk
libstdc++               12.2.1_git20220924-r10  apk
musl                    1.2.4-r2                apk
musl-utils              1.2.4-r2                apk
scanelf                 1.3.7-r1                apk
ssl_client              1.36.1-r5               apk
zlib                    1.2.13-r1               apk
```

After:
```
✔ Packages                               [6 packages]
   └── ✔ Executables                     [30 executables]
NAME             VERSION                TYPE
base-files       13ubuntu10             deb
ca-certificates  20240203               deb
libc6            2.39-0ubuntu8          deb
libgcc-s1        14-20240412-0ubuntu1   deb
libssl3t64       3.0.13-0ubuntu3        deb
zlib1g           1:1.3.dfsg-3.1ubuntu2  deb
```

## CVEs (+2 `LOW` and -4 `MEDIUM`)

_Note: [`trivy`](https://aquasecurity.github.io/trivy) was used._

Before:
```
(alpine 3.18.6)

Total: 7 (UNKNOWN: 0, LOW: 2, MEDIUM: 5, HIGH: 0, CRITICAL: 0)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2023-42366 │ MEDIUM   │ fixed  │ 1.36.1-r5         │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┤                │          │        │                   │               │                                                           │
│ busybox-binsh │                │          │        │                   │               │                                                           │
│               │                │          │        │                   │               │                                                           │
├───────────────┼────────────────┤          │        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2024-4603  │          │        │ 3.1.4-r5          │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2024-4603  │ MEDIUM   │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2023-42366 │ MEDIUM   │        │ 1.36.1-r5         │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

After:
```
(ubuntu 24.04)

Total: 5 (UNKNOWN: 0, LOW: 4, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬──────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │  Status  │ Installed Version │  Fixed Version  │                           Title                            │
├────────────┼────────────────┼──────────┼──────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ libc6      │ CVE-2024-2961  │ MEDIUM   │ fixed    │ 2.39-0ubuntu8     │ 2.39-0ubuntu8.1 │ glibc: Out of bounds write in iconv may lead to remote     │
│            │                │          │          │                   │                 │ code...                                                    │
│            │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-2961                  │
│            ├────────────────┼──────────┼──────────┤                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2016-20013 │ LOW      │ affected │                   │                 │ sha256crypt and sha512crypt through 0.6 allow attackers to │
│            │                │          │          │                   │                 │ cause a denial of...                                       │
│            │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2016-20013                 │
├────────────┼────────────────┤          │          ├───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ libssl3t64 │ CVE-2024-2511  │          │          │ 3.0.13-0ubuntu3   │                 │ openssl: Unbounded memory growth with session handling in  │
│            │                │          │          │                   │                 │ TLSv1.3                                                    │
│            │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-2511                  │
│            ├────────────────┤          │          │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2024-4603  │          │          │                   │                 │ openssl: Excessive time spent checking DSA keys and        │
│            │                │          │          │                   │                 │ parameters                                                 │
│            │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-4603                  │
│            ├────────────────┤          │          │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2024-4741  │          │          │                   │                 │ openssl: Use After Free with SSL_free_buffers              │
│            │                │          │          │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-4741                  │
└────────────┴────────────────┴──────────┴──────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```