### PR TITLE
`arm64` support

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: authenticate to google cloud
         uses: google-github-actions/auth@v2
         with:
@@ -35,30 +39,19 @@ jobs:
           gcloud auth configure-docker \
               ${{ secrets.REGISTRY_LOCATION }}-docker.pkg.dev \
               --quiet
-      - name: build container
-        run: |
-          docker build \
-              --tag ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
-              app/
-      - name: push container to gar
-        run: |
-          docker push \
-              ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       - name: login to ghcr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login \
               ghcr.io \
               -u $ \
               --password-stdin
-      - name: tag container for ghcr
-        run: |
-          docker tag \
-              ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
-              ghcr.io/${{ github.repository_owner }}/${{ env.WORKLOAD_NAME }}:latest
-      - name: push container in ghcr
-        run: |
-          docker push \
-              ghcr.io/${{ github.repository_owner }}/${{ env.WORKLOAD_NAME }}:latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: app/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.WORKLOAD_NAME }}:latest"
   deploy-humanitec:
     needs: build-push
     runs-on: ubuntu-24.04

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,17 +2,17 @@
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
 # https://mcr.microsoft.com/product/dotnet/nightly/sdk
 # https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/nightly/sdk:9.0.100-noble-aot AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/nightly/sdk:9.0.100-noble-aot AS builder
+ARG TARGETARCH
 WORKDIR /app
 COPY my-sample-app.csproj .
 RUN dotnet restore my-sample-app.csproj \
-    -r linux-x64
+    -a $TARGETARCH
 COPY . .
 RUN dotnet publish my-sample-app.csproj \
-    -r linux-x64 \
+    -a $TARGETARCH \
     -c release \
     -o /my-sample-app \
-    --no-restore \
     --self-contained true \
     -p:PublishTrimmed=true \
     -p:TrimMode=full
@@ -27,4 +27,4 @@ COPY --from=builder /my-sample-app .
 EXPOSE 8080
 ENV ASPNETCORE_HTTP_PORTS=8080
 USER 65532
-ENTRYPOINT ["/app/my-sample-app"]
+ENTRYPOINT ["./my-sample-app"]

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
+using System.Runtime.InteropServices;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 builder.Configuration.AddJsonFile("appsettings.json", true, true);
@@ -9,6 +10,9 @@ var app = builder.Build();
 var message = builder.Configuration["MESSAGE"] ?? "Hello, World! (from code)";
 var podName = builder.Configuration["POD_NAME"];
 var namespaceName = builder.Configuration["NAMESPACE_NAME"];
+message = string.IsNullOrEmpty(podName) || string.IsNullOrEmpty(namespaceName) ? message : $"{message} - from {podName} / {namespaceName}";
+var platform = RuntimeInformation.OSArchitecture;
+var platformValue = platform == Architecture.Arm64 ? "arm64" : "amd64" ;
 
-app.MapGet("/", () => string.IsNullOrEmpty(podName) || string.IsNullOrEmpty(namespaceName) ? message : $"{message} - from {podName} / {namespaceName}.");
+app.MapGet("/", () => $"{message} on {platformValue}.");
 app.Run();


### PR DESCRIPTION
- https://docs.docker.com/build/building/multi-platform/
- https://www.chainguard.dev/unchained/building-multiarch-images-with-chainguard-images
- https://cloud.google.com/kubernetes-engine/docs/how-to/build-multi-arch-for-arm
- https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/

Tests with:
- Other PR: https://github.com/mathieu-benoit/sail-sharp/pull/137.
- `docker build .`
- `docker build --platform arm64`
- `docker build --platform amd64`

`oras manifest fetch ghcr.io/mathieu-benoit/my-sample-workload:test`:
```
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:f6d97472cd25f02f9413ec5217d373d1fcf4d9aa24ad829a71055e22e446428e",
      "size": 1048,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:38348f6e9b52544b77d80800000526c728ce97bc66db44d5e03fdab7043c3845",
      "size": 1048,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:75aaafea9befce846dbaf87a30826a195eb174c69fcfcf5f2097c3334eeb57ef",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:f6d97472cd25f02f9413ec5217d373d1fcf4d9aa24ad829a71055e22e446428e",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2a03475e11b4b40e7f0dd53e99b4fb15eb58b2e3694e9b9ae4bff89c5bc4381b",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:38348f6e9b52544b77d80800000526c728ce97bc66db44d5e03fdab7043c3845",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
}
```


_Note: I needed to remove `--no-restore` in the `dotnet pulish` command otherwise getting this error: `/usr/share/dotnet/sdk/9.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(495,5): error NETSDK1112: The runtime pack for Microsoft.AspNetCore.App.Runtime.linux-x64 was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'linux-x64'. [/app/my-sample-app.csproj]`._